### PR TITLE
Bug: Fix Detail Header not loading

### DIFF
--- a/Modules/Features/Album/Album/Sources/Endpoint /FeatureFactory+AlbumEndpoint.swift
+++ b/Modules/Features/Album/Album/Sources/Endpoint /FeatureFactory+AlbumEndpoint.swift
@@ -7,6 +7,6 @@ extension FeatureFactory {
   }
 
   public func albumDetailURL(forAlbumID id: Int) -> URL {
-    AlbumEndpoint.tracks(id: id).url(baseURL: baseURL)
+    AlbumEndpoint.album(id: id).url(baseURL: baseURL)
   }
 }

--- a/Modules/Features/Album/AlbumIOS/Sources/FeatureFactory/FeatureFactory+AlbumDetail.swift
+++ b/Modules/Features/Album/AlbumIOS/Sources/FeatureFactory/FeatureFactory+AlbumDetail.swift
@@ -14,7 +14,7 @@ extension FeatureFactory {
     onTrackSelection: @escaping (Int) -> Void
   ) -> UIViewController {
     let remoteAlbumLoader = RemoteAlbumLoader(
-      url: albumTracksURL(forAlbumID: id),
+      url: albumDetailURL(forAlbumID: id),
       client: httpClient
     )
 


### PR DESCRIPTION
The album detail was using the wrong url to make the detail album load. 