### PR TITLE
Weak Reference Proxy Implementation

### DIFF
--- a/Apps/iOS/iOSApp/Sources/ArtistSearch/ArtistSearchSceneCoordinator.swift
+++ b/Apps/iOS/iOSApp/Sources/ArtistSearch/ArtistSearchSceneCoordinator.swift
@@ -1,5 +1,6 @@
 import AlbumIOS
 import ArtistIOS
+import Core
 import Shared
 import UI
 import UIKit
@@ -45,8 +46,7 @@ extension ArtistSearchSceneCoordinator: ArtistSearchCoordinatorDelegate {
 
     addChild(coordinator)
 
-    // TODO: WeakReference Proxy
-    coordinator.delegate = self
+    coordinator.delegate = WeakRefVirtualProxy(self)
     coordinator.start()
   }
 }

--- a/Apps/iOS/iOSApp/Sources/ArtistSearch/ArtistSearchSceneCoordinator.swift
+++ b/Apps/iOS/iOSApp/Sources/ArtistSearch/ArtistSearchSceneCoordinator.swift
@@ -21,8 +21,7 @@ final class ArtistSearchSceneCoordinator: Coordinator {
     let coordinator = artistSearchCoordinator()
     addChild(coordinator)
 
-    // TODO: WeakReference Proxy
-    coordinator.delegate = self
+    coordinator.delegate = WeakRefVirtualProxy(self)
     coordinator.start()
   }
 

--- a/Modules/Features/Album/Album.xcodeproj/project.pbxproj
+++ b/Modules/Features/Album/Album.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -18,6 +18,7 @@
 		38C61C9452C85E8F5FA08CB7 /* SharedIOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8A8EFD299D81E0BE1C7D883C /* SharedIOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3D3F22E440F25F720FFD65C2 /* TuistBundle+AlbumApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F134C40D167263F3DCC73BD9 /* TuistBundle+AlbumApp.swift */; };
 		3EFB72F67DA5513A0BD54134 /* RemoteAlbumsLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267F361A4158DFF618CE7FB8 /* RemoteAlbumsLoader.swift */; };
+		46C38C2D2A2CE3A000A8EAE6 /* WeakReferenceProxy+AlbumLIstCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C38C2C2A2CE3A000A8EAE6 /* WeakReferenceProxy+AlbumLIstCoordinatorDelegate.swift */; };
 		46FF3F0C337FD0EBDA489039 /* Networking.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D05309141F4B929D8CD9F718 /* Networking.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4A38E2BDA9730B40E586EBC6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E0CBD4E25932B5B17C00EA /* AppDelegate.swift */; };
 		512A3ECE0F5B2D1B43888463 /* Album.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 29F4D58122690B01592D4EE9 /* Album.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -200,6 +201,7 @@
 		42A20D9F96A74241D3594F88 /* AlbumImageTitleRowViewModelAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumImageTitleRowViewModelAdapter.swift; sourceTree = "<group>"; };
 		446F7A078E0616DE9CF586C8 /* AlbumCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumCoordinatorTests.swift; sourceTree = "<group>"; };
 		45C7FBD8FD7954474D874309 /* AlbumIOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AlbumIOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		46C38C2C2A2CE3A000A8EAE6 /* WeakReferenceProxy+AlbumLIstCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WeakReferenceProxy+AlbumLIstCoordinatorDelegate.swift"; sourceTree = "<group>"; };
 		4CA21183E6745AAC2799FAAE /* Album+ImageTitleRowModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Album+ImageTitleRowModel.swift"; sourceTree = "<group>"; };
 		4D97588A97FF8C919566919A /* FeatureFactory+AlbumEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeatureFactory+AlbumEndpoint.swift"; sourceTree = "<group>"; };
 		540E4DCDED35073BCE003047 /* AlbumApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AlbumApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -385,6 +387,14 @@
 			path = "Album+ImageTitleRow";
 			sourceTree = "<group>";
 		};
+		46C38C2B2A2CE2DF00A8EAE6 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				46C38C2C2A2CE3A000A8EAE6 /* WeakReferenceProxy+AlbumLIstCoordinatorDelegate.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		492B3F2A8FCA9B4A17C35323 = {
 			isa = PBXGroup;
 			children = (
@@ -556,6 +566,7 @@
 		8B90914E36DD6BAEC33EAE56 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				46C38C2B2A2CE2DF00A8EAE6 /* Extensions */,
 				662A38E034DD4594870CB719 /* Adapters */,
 				765A29A151507C28C5C8274E /* AlbumDetail */,
 				CF3DCCA97A5365AFA3A32129 /* AlbumList */,
@@ -818,8 +829,6 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1430;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = 5DE92884AD721106EEA88238 /* Build configuration list for PBXProject "Album" */;
 			compatibilityVersion = "Xcode 13.0";
@@ -1034,6 +1043,7 @@
 				60A4B9915164191F5120F69F /* Album+DetailHeaderModel.swift in Sources */,
 				7D611CFBD0D32D91AD1856F0 /* AlbumDetailHeaderModelAdapter.swift in Sources */,
 				D79114E81768FC4A363AAF97 /* Album+ImageTitleRowModel.swift in Sources */,
+				46C38C2D2A2CE3A000A8EAE6 /* WeakReferenceProxy+AlbumLIstCoordinatorDelegate.swift in Sources */,
 				D595BB8FCD3E976D5CC4C6D3 /* AlbumImageTitleRowViewModelAdapter.swift in Sources */,
 				83950E5A73AEA48CC2D58062 /* AlbumDetailView.swift in Sources */,
 				5427A6016EAE80DDCF3387B7 /* AlbumDetailViewController.swift in Sources */,

--- a/Modules/Features/Album/AlbumApp/Sources/Main/MainCoordinator.swift
+++ b/Modules/Features/Album/AlbumApp/Sources/Main/MainCoordinator.swift
@@ -1,5 +1,6 @@
 import Album
 import AlbumIOS
+import Core
 import Networking
 import Shared
 import UI
@@ -21,8 +22,7 @@ public final class MainCoordinator: Coordinator, FeatureFactory {
   public func start() {
     let coordinator = albumListCoordinator()
     addChild(coordinator)
-    // TODO: WeakReference Proxy
-    coordinator.delegate = self
+    coordinator.delegate = WeakRefVirtualProxy(self)
 
     coordinator.start()
   }

--- a/Modules/Features/Album/AlbumIOS/Sources/Extensions/WeakReferenceProxy+AlbumLIstCoordinatorDelegate.swift
+++ b/Modules/Features/Album/AlbumIOS/Sources/Extensions/WeakReferenceProxy+AlbumLIstCoordinatorDelegate.swift
@@ -1,0 +1,7 @@
+import Core
+
+extension WeakRefVirtualProxy: AlbumListCoordinatorDelegate where T: AlbumListCoordinatorDelegate {
+  public func didSelectTrack(withID id: Int) {
+    object?.didSelectTrack(withID: id)
+  }
+}

--- a/Modules/Features/Artist/Artist.xcodeproj/project.pbxproj
+++ b/Modules/Features/Artist/Artist.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -21,6 +21,7 @@
 		375687B6C4BAE0DEAF20D084 /* Artist.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99DEB5F180440477F9500360 /* Artist.framework */; };
 		38058385CAE735155B891303 /* Artist.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99DEB5F180440477F9500360 /* Artist.framework */; };
 		458541D5B13667BEBAAA49BC /* TuistAssets+ArtistApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56714E014DDA3AF88967637F /* TuistAssets+ArtistApp.swift */; };
+		46C38C312A2CE6AE00A8EAE6 /* WeakReferenceProxy+AlbumLIstCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C38C2F2A2CE68F00A8EAE6 /* WeakReferenceProxy+AlbumLIstCoordinatorDelegate.swift */; };
 		4E6601DADBBC278FB8BA657A /* Shared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C2372AF75C28967F06773D9D /* Shared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		51E2BC7F99A751A9393D5DC3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AAAA6A69DBFF86C0C4560A46 /* Assets.xcassets */; };
 		52459E91B8E16A8752C68D46 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CA9FC44A183327DE24EB74D4 /* LaunchScreen.storyboard */; };
@@ -181,6 +182,7 @@
 		2A96AA91578DF03B3A0C8D76 /* Artist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artist.swift; sourceTree = "<group>"; };
 		2B12F7F20AAA266271938E78 /* TuistAssets+ArtistIOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistAssets+ArtistIOS.swift"; sourceTree = "<group>"; };
 		3F7A179FEACB196B948DD36D /* ArtistsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistsMapper.swift; sourceTree = "<group>"; };
+		46C38C2F2A2CE68F00A8EAE6 /* WeakReferenceProxy+AlbumLIstCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WeakReferenceProxy+AlbumLIstCoordinatorDelegate.swift"; sourceTree = "<group>"; };
 		47D868B4E8FAD8C7FFDEA02D /* TuistBundle+ArtistIOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistBundle+ArtistIOS.swift"; sourceTree = "<group>"; };
 		4E8800FC82889EA91F5781E4 /* ArtistTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ArtistTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		56714E014DDA3AF88967637F /* TuistAssets+ArtistApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistAssets+ArtistApp.swift"; sourceTree = "<group>"; };
@@ -356,6 +358,7 @@
 		223F05289A1D816B853B386E /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				46C38C2E2A2CE68300A8EAE6 /* Extensions */,
 				A1C5F7CBCA1DD001B813E5A9 /* Adapters */,
 				A093F9B2E15C2C3E2EDBB528 /* ArtistSearchList */,
 				F4B74240C1082283299872EB /* FeatureFactory */,
@@ -411,6 +414,14 @@
 				9369E8183A7C8F4D863A390D /* Tests */,
 			);
 			path = ArtistAPIIntegrationTests;
+			sourceTree = "<group>";
+		};
+		46C38C2E2A2CE68300A8EAE6 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				46C38C2F2A2CE68F00A8EAE6 /* WeakReferenceProxy+AlbumLIstCoordinatorDelegate.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		46DBB5C53155B089543AA9CA /* ArtistApp */ = {
@@ -746,8 +757,6 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1430;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = BD3150C2E4392EF07C13C826 /* Build configuration list for PBXProject "Artist" */;
 			compatibilityVersion = "Xcode 13.0";
@@ -1001,6 +1010,7 @@
 				85A711CAB21D0436A8ED51B0 /* FeatureFactory+ArtistSearchViewController.swift in Sources */,
 				336AC2E6A0240F3B179AB6D4 /* TuistAssets+ArtistIOS.swift in Sources */,
 				6BBFAF89CC8D2DD5E5FFDA5E /* TuistBundle+ArtistIOS.swift in Sources */,
+				46C38C312A2CE6AE00A8EAE6 /* WeakReferenceProxy+AlbumLIstCoordinatorDelegate.swift in Sources */,
 				0D6E7FF1D536F42DC3533F9F /* TuistStrings+ArtistIOS.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Modules/Features/Artist/ArtistApp/Sources/Main/MainCoordinator.swift
+++ b/Modules/Features/Artist/ArtistApp/Sources/Main/MainCoordinator.swift
@@ -23,8 +23,7 @@ final class MainCoordinator: Coordinator, FeatureFactory {
   func start() {
     let coordinator = artistSearchCoordinator()
     addChild(coordinator)
-    // TODO: Implement WeakRefProxy
-    coordinator.delegate = self
+    coordinator.delegate = WeakRefVirtualProxy(self)
 
     coordinator.start()
   }

--- a/Modules/Features/Artist/ArtistApp/Sources/Main/MainCoordinator.swift
+++ b/Modules/Features/Artist/ArtistApp/Sources/Main/MainCoordinator.swift
@@ -23,7 +23,7 @@ final class MainCoordinator: Coordinator, FeatureFactory {
   func start() {
     let coordinator = artistSearchCoordinator()
     addChild(coordinator)
-    // TODO: WeakReference Proxy
+    // TODO: Implement WeakRefProxy
     coordinator.delegate = self
 
     coordinator.start()

--- a/Modules/Features/Artist/ArtistIOS/Sources/Extensions/WeakReferenceProxy+AlbumLIstCoordinatorDelegate.swift
+++ b/Modules/Features/Artist/ArtistIOS/Sources/Extensions/WeakReferenceProxy+AlbumLIstCoordinatorDelegate.swift
@@ -1,0 +1,7 @@
+import Core
+
+extension WeakRefVirtualProxy: ArtistSearchCoordinatorDelegate where T: ArtistSearchCoordinatorDelegate {
+  public func didSelectArtist(withID id: Int) {
+    object?.didSelectArtist(withID: id)
+  }
+}

--- a/Modules/Features/Track/Track.xcodeproj/project.pbxproj
+++ b/Modules/Features/Track/Track.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -18,6 +18,7 @@
 		29EB0DF57D328FA42374205F /* TuistBundle+TrackApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7892C7A9D294D335C57C533A /* TuistBundle+TrackApp.swift */; };
 		316EB42AE964880EF28B48FB /* Track.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8304BCE1EF81761A36D7CDFF /* Track.framework */; };
 		35898D6D5BC86CCF1FF2C303 /* Track.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8304BCE1EF81761A36D7CDFF /* Track.framework */; };
+		46C38C352A2CE93500A8EAE6 /* WeakReferenceProxy+TrackLIstCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C38C342A2CE93500A8EAE6 /* WeakReferenceProxy+TrackLIstCoordinatorDelegate.swift */; };
 		4E429FF15B761E0F02719616 /* SharedIOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 67FF9BF213AF31E8692F0B55 /* SharedIOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4FB7AD3F7911296748E752D0 /* SharedIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67FF9BF213AF31E8692F0B55 /* SharedIOS.framework */; };
 		518DAA2691C0FD0DD7589772 /* TuistAssets+TrackApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD4E932D6675152C24071C4 /* TuistAssets+TrackApp.swift */; };
@@ -184,6 +185,7 @@
 		3169C3E6A6E8618BE9F18344 /* Track+TrackRowModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Track+TrackRowModel.swift"; sourceTree = "<group>"; };
 		4129CB7708C11D8B81C42EF5 /* TrackAPIIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TrackAPIIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		430968C6BB30FA6572FEDBD4 /* TrackIOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TrackIOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		46C38C342A2CE93500A8EAE6 /* WeakReferenceProxy+TrackLIstCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WeakReferenceProxy+TrackLIstCoordinatorDelegate.swift"; sourceTree = "<group>"; };
 		47434F05DF2929DB1B1BF6D3 /* Shared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Shared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B77390AF3F7EDA97FEC9EDF /* TrackListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackListViewController.swift; sourceTree = "<group>"; };
 		4D8B251F8D54DFC2CE47996B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -386,6 +388,7 @@
 		430BB53568BB42608665AB8C /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				46C38C322A2CE91700A8EAE6 /* Extensions */,
 				457BCC574C8706201A0F1A57 /* Adapters */,
 				B25728EF5D4D6915ADB5D104 /* FeatureFactory */,
 				465D41143BE8518B9B3B5F82 /* TrackList */,
@@ -419,6 +422,14 @@
 				B9A42AC9D43D32427AD55BEC /* TrackListViewModel.swift */,
 			);
 			path = TrackList;
+			sourceTree = "<group>";
+		};
+		46C38C322A2CE91700A8EAE6 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				46C38C342A2CE93500A8EAE6 /* WeakReferenceProxy+TrackLIstCoordinatorDelegate.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		498209665FC763CA3A287EF5 /* TrackTests */ = {
@@ -746,8 +757,6 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1430;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = D9702FE94D7EAA027FF684B7 /* Build configuration list for PBXProject "Track" */;
 			compatibilityVersion = "Xcode 13.0";
@@ -991,6 +1000,7 @@
 				7FC69C544847FCDFB2D8FEFF /* TrackListView.swift in Sources */,
 				CB88F26092281939D1EEFC84 /* TrackListViewController.swift in Sources */,
 				03B80A7CCA9A1270CA7D5C1D /* TrackListViewModel.swift in Sources */,
+				46C38C352A2CE93500A8EAE6 /* WeakReferenceProxy+TrackLIstCoordinatorDelegate.swift in Sources */,
 				77EC592D6D148D665BE5D34E /* TrackListCoordinator.swift in Sources */,
 				84E28C44A2E2AA9D2B71B2B6 /* TrackRowModel.swift in Sources */,
 				217FDC8A2BAFD0D197DBC263 /* TrackRowView.swift in Sources */,

--- a/Modules/Features/Track/TrackApp/Sources/Main/MainCoordinator.swift
+++ b/Modules/Features/Track/TrackApp/Sources/Main/MainCoordinator.swift
@@ -23,8 +23,7 @@ final class MainCoordinator: Coordinator, FeatureFactory {
   func start() {
     let coordinator = trackListCoordinator()
     addChild(coordinator)
-    // TODO: WeakReference Proxy
-    coordinator.delegate = self
+    coordinator.delegate = WeakRefVirtualProxy(self)
 
     coordinator.start()
   }

--- a/Modules/Features/Track/TrackIOS/Sources/Extensions/WeakReferenceProxy+TrackLIstCoordinatorDelegate.swift
+++ b/Modules/Features/Track/TrackIOS/Sources/Extensions/WeakReferenceProxy+TrackLIstCoordinatorDelegate.swift
@@ -1,0 +1,7 @@
+import Core
+
+extension WeakRefVirtualProxy: TrackListCoordinatorDelegate where T: TrackListCoordinatorDelegate {
+  public func didSelectTrack(withID id: Int) {
+    object?.didSelectTrack(withID: id)
+  }
+}

--- a/Modules/Foundation/Core/Core.xcodeproj/project.pbxproj
+++ b/Modules/Foundation/Core/Core.xcodeproj/project.pbxproj
@@ -3,13 +3,14 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		17DD45C17E35897BE85F130B /* Sequence+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F8362B18E5F5925399BE28D /* Sequence+Async.swift */; };
 		185B0A89C3A8D35CCD0B09E4 /* AsyncStream+Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 990F480F47C862E63696EECC /* AsyncStream+Empty.swift */; };
 		3A59A65FE264F18D0DF5C7AC /* Bundle+Displayname.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EAC707571059C4F574AF288 /* Bundle+Displayname.swift */; };
+		46C38C2A2A2CE2A200A8EAE6 /* WeakReferenceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C38C292A2CE2A200A8EAE6 /* WeakReferenceProxy.swift */; };
 		5185366F166AC62ACE3B54CD /* Testing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DFA1D869C524184A4F0CB506 /* Testing.framework */; };
 		6D676AD58F630C0DC3DA20A5 /* DateFormatter+Locale.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50667F53236117C9D9572E6 /* DateFormatter+Locale.swift */; };
 		83C544D4D4686FA1952B5CDA /* Collection+SubscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEDC9AE444306AE8DFA5B1 /* Collection+SubscriptTests.swift */; };
@@ -60,6 +61,7 @@
 		2B0FA7F85F3573FB522F9478 /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3E313EC3E53C9ED17660FD3F /* CoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		416ECD39AF17BAA633D3319F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		46C38C292A2CE2A200A8EAE6 /* WeakReferenceProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakReferenceProxy.swift; sourceTree = "<group>"; };
 		5BCC03F920AFF8EA5E089C03 /* Publisher+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Async.swift"; sourceTree = "<group>"; };
 		6EAC707571059C4F574AF288 /* Bundle+Displayname.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Displayname.swift"; sourceTree = "<group>"; };
 		7B04754C559CBA9E8C603FFB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -125,6 +127,14 @@
 				DFA1D869C524184A4F0CB506 /* Testing.framework */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		46C38C282A2CE28F00A8EAE6 /* Types */ = {
+			isa = PBXGroup;
+			children = (
+				46C38C292A2CE2A200A8EAE6 /* WeakReferenceProxy.swift */,
+			);
+			path = Types;
 			sourceTree = "<group>";
 		};
 		4CAD6DE1CEAC19C7F1820908 /* Tests */ = {
@@ -209,6 +219,7 @@
 		BBC5F1602D420DAE023BC046 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				46C38C282A2CE28F00A8EAE6 /* Types */,
 				08B2F0C29AD0DFA0D79CB1C0 /* Extensions */,
 				9A791C5B7F0CE5E6A4B595E4 /* Protocols */,
 			);
@@ -282,8 +293,6 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1430;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = 4EBE82DE9849E8F47BAECD7B /* Build configuration list for PBXProject "Core" */;
 			compatibilityVersion = "Xcode 13.0";
@@ -377,6 +386,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AE9B9D07BEA80A43539D42AC /* Publisher+Async.swift in Sources */,
+				46C38C2A2A2CE2A200A8EAE6 /* WeakReferenceProxy.swift in Sources */,
 				185B0A89C3A8D35CCD0B09E4 /* AsyncStream+Empty.swift in Sources */,
 				3A59A65FE264F18D0DF5C7AC /* Bundle+Displayname.swift in Sources */,
 				BA2D9C3AA39978DC42C45AA5 /* Collection+Subscript.swift in Sources */,

--- a/Modules/Foundation/Core/Core/Sources/Types/WeakReferenceProxy.swift
+++ b/Modules/Foundation/Core/Core/Sources/Types/WeakReferenceProxy.swift
@@ -1,0 +1,7 @@
+public final class WeakRefVirtualProxy<T: AnyObject> {
+  public weak var object: T?
+
+  public init(_ object: T) {
+    self.object = object
+  }
+}


### PR DESCRIPTION
Add the `WeakReferenceProxy` type to allow _weaking_ an object upon assignment instead of having to leak the implementation to the class itself.

Apply the `WeakReferenceProxy` for all the coordinator delegates.
