### PR TITLE
Address TODO warnings

### DIFF
--- a/Modules/Features/Album/AlbumAPIIntegrationTests/Tests/AlbumAPIIntegrationTests.swift
+++ b/Modules/Features/Album/AlbumAPIIntegrationTests/Tests/AlbumAPIIntegrationTests.swift
@@ -1,4 +1,5 @@
 import Album
+import Core
 import Networking
 import Testing
 import XCTest
@@ -44,19 +45,4 @@ final class AlbumAPIIntegrationTests: XCTestCase {
       XCTFail("Expected successful albums result, got \(error) instead")
     }
   }
-}
-
-// TODO: Move to core
-extension String {
-  func asISO8601FullDate() -> Date? {
-    let formatter = Formatter.iso8601
-    formatter.formatOptions = [.withFullDate]
-
-    return formatter.date(from: self)
-  }
-}
-
-// TODO: Look for duplication here
-extension Formatter {
-  static let iso8601 = ISO8601DateFormatter()
 }

--- a/Modules/Features/Album/AlbumTests/Tests/RemoteAlbumLoading/RemoteAlbumLoaderTests.swift
+++ b/Modules/Features/Album/AlbumTests/Tests/RemoteAlbumLoading/RemoteAlbumLoaderTests.swift
@@ -72,10 +72,9 @@ final class RemoteAlbumLoaderTests: XCTestCase {
     let url = anyURL()
     let (sut, client) = makeSUT(url: url)
 
-    // TODO: Clean up dirty data below (.dataCorrupted)
     try await expect(
       sut,
-      toCompleteWith: .failure(.invalidData(.decoding(.dataCorrupted(.init(codingPath: [], debugDescription: ""))))),
+      toCompleteWith: .failure(.invalidData(.decoding(.anyDataCorruptedError()))),
       when: {
         client.complete(withStatusCode: 200, data: invalidJSONData(), for: url)
       }

--- a/Modules/Features/Album/AlbumTests/Tests/RemoteAlbumLoading/RemoteAlbumLoaderTests.swift
+++ b/Modules/Features/Album/AlbumTests/Tests/RemoteAlbumLoading/RemoteAlbumLoaderTests.swift
@@ -222,7 +222,6 @@ extension RemoteAlbumLoaderTests {
     for sut: SUT,
     timeout seconds: TimeInterval = 2
   ) async throws -> Entity {
-    // FIXME: The `unowned sut` is a weird one. The timeout task is holding onto sut for some reason
     try await timeoutTask(timeout: seconds) { [unowned sut] in
       try await sut.load()
     }

--- a/Modules/Features/Album/AlbumTests/Tests/RemoteAlbumsLoading/RemoteAlbumsLoaderTests.swift
+++ b/Modules/Features/Album/AlbumTests/Tests/RemoteAlbumsLoading/RemoteAlbumsLoaderTests.swift
@@ -72,10 +72,9 @@ final class RemoteAlbumsLoaderTests: XCTestCase {
     let url = anyURL()
     let (sut, client) = makeSUT(url: url)
 
-    // TODO: Clean up dirty data below (.dataCorrupted)
     try await expect(
       sut,
-      toCompleteWith: .failure(.invalidData(.decoding(.dataCorrupted(.init(codingPath: [], debugDescription: ""))))),
+      toCompleteWith: .failure(.invalidData(.decoding(.anyDataCorruptedError()))),
       when: {
         client.complete(withStatusCode: 200, data: invalidJSONData(), for: url)
       }

--- a/Modules/Features/Album/AlbumTests/Tests/RemoteAlbumsLoading/RemoteAlbumsLoaderTests.swift
+++ b/Modules/Features/Album/AlbumTests/Tests/RemoteAlbumsLoading/RemoteAlbumsLoaderTests.swift
@@ -357,18 +357,3 @@ extension RemoteAlbumsLoaderTests {
     return try! JSONSerialization.data(withJSONObject: json)
   }
 }
-
-// TODO: Move to test helpers/Core
-extension Date {
-  func asISO8601FullDateString() -> String {
-    let formatter = Formatter.iso8601
-    formatter.formatOptions = [.withFullDate]
-
-    return formatter.string(from: self)
-  }
-}
-
-// TODO: Move to test helpers/Core
-extension Formatter {
-  static let iso8601 = ISO8601DateFormatter()
-}

--- a/Modules/Features/Album/AlbumTests/Tests/RemoteAlbumsLoading/RemoteAlbumsLoaderTests.swift
+++ b/Modules/Features/Album/AlbumTests/Tests/RemoteAlbumsLoading/RemoteAlbumsLoaderTests.swift
@@ -274,7 +274,6 @@ extension RemoteAlbumsLoaderTests {
     for sut: SUT,
     timeout seconds: TimeInterval = 2
   ) async throws -> [Entity] {
-    // FIXME: The `unowned sut` is a weird one. The timeout task is holding onto sut for some reason
     try await timeoutTask(timeout: seconds) { [unowned sut] in
       try await sut.load()
     }

--- a/Modules/Features/Artist/ArtistTests/Tests/ArtistSearchLoading/RemoteArtistSearchLoaderTests.swift
+++ b/Modules/Features/Artist/ArtistTests/Tests/ArtistSearchLoading/RemoteArtistSearchLoaderTests.swift
@@ -97,11 +97,10 @@ final class RemoteArtistSearchLoaderTests: XCTestCase {
     let search = makeSearchFixture()
     let (sut, client) = makeSUT(url: search.baseURL)
 
-    // TODO: Clean up dirty data below (.dataCorrupted)
     try await expect(
       sut,
       with: search.queryString,
-      toCompleteWith: .failure(.invalidData(.decoding(.dataCorrupted(.init(codingPath: [], debugDescription: ""))))),
+      toCompleteWith: .failure(.invalidData(.decoding(.anyDataCorruptedError()))),
       when: {
         client.complete(withStatusCode: 200, data: invalidJSONData(), for: search.urlWithQuery)
       }

--- a/Modules/Features/Artist/ArtistTests/Tests/ArtistSearchLoading/RemoteArtistSearchLoaderTests.swift
+++ b/Modules/Features/Artist/ArtistTests/Tests/ArtistSearchLoading/RemoteArtistSearchLoaderTests.swift
@@ -261,7 +261,6 @@ extension RemoteArtistSearchLoaderTests {
     for sut: SUT,
     timeout seconds: TimeInterval = 2
   ) async throws -> [Entity] {
-    // FIXME: The `unowned sut` is a weird one. The timeout task is holding onto sut for some reason
     try await timeoutTask(timeout: seconds) { [unowned sut] in
       try await sut.load(query)
     }

--- a/Modules/Features/Shared/SharedTests/Tests/RemoteLoading/RemoteImageDataLoaderTests.swift
+++ b/Modules/Features/Shared/SharedTests/Tests/RemoteLoading/RemoteImageDataLoaderTests.swift
@@ -84,11 +84,10 @@ final class RemoteImageDataLoaderTests: XCTestCase {
     let url = URL.anyURL()
     let (sut, client) = makeSUT()
 
-    // TODO: Clean up dirty data below (.dataCorrupted)
     try await expect(
       sut,
       with: url,
-      toCompleteWith: .failure(.invalidData(.decoding(.dataCorrupted(.init(codingPath: [], debugDescription: ""))))),
+      toCompleteWith: .failure(.invalidData(.decoding(.anyDataCorruptedError()))),
       when: {
         client.complete(withStatusCode: 200, data: Data(), for: url)
       }

--- a/Modules/Features/Shared/SharedTests/Tests/RemoteLoading/RemoteImageDataLoaderTests.swift
+++ b/Modules/Features/Shared/SharedTests/Tests/RemoteLoading/RemoteImageDataLoaderTests.swift
@@ -229,7 +229,6 @@ extension RemoteImageDataLoaderTests {
     for sut: SUT,
     timeout seconds: TimeInterval = 2
   ) async throws -> Entity {
-    // FIXME: The `unowned sut` is a weird one. The timeout task is holding onto sut for some reason
     try await timeoutTask(timeout: seconds) { [unowned sut] in
       try await sut.load(url)
     }

--- a/Modules/Features/Track/TrackTests/Tests/TrackLoading/RemoteTracksLoaderTests.swift
+++ b/Modules/Features/Track/TrackTests/Tests/TrackLoading/RemoteTracksLoaderTests.swift
@@ -231,7 +231,6 @@ extension RemoteTracksLoaderTests {
     for sut: SUT,
     timeout seconds: TimeInterval = 2
   ) async throws -> [Entity] {
-    // FIXME: The `unowned sut` is a weird one. The timeout task is holding onto sut for some reason
     try await timeoutTask(timeout: seconds) { [unowned sut] in
       try await sut.load()
     }

--- a/Modules/Foundation/Core/Core.xcodeproj/project.pbxproj
+++ b/Modules/Foundation/Core/Core.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		185B0A89C3A8D35CCD0B09E4 /* AsyncStream+Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 990F480F47C862E63696EECC /* AsyncStream+Empty.swift */; };
 		3A59A65FE264F18D0DF5C7AC /* Bundle+Displayname.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EAC707571059C4F574AF288 /* Bundle+Displayname.swift */; };
 		46C38C2A2A2CE2A200A8EAE6 /* WeakReferenceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C38C292A2CE2A200A8EAE6 /* WeakReferenceProxy.swift */; };
+		46C38C3C2A2CF07C00A8EAE6 /* Date+ISO8601FullDateString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C38C3B2A2CF07C00A8EAE6 /* Date+ISO8601FullDateString.swift */; };
 		5185366F166AC62ACE3B54CD /* Testing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DFA1D869C524184A4F0CB506 /* Testing.framework */; };
 		6D676AD58F630C0DC3DA20A5 /* DateFormatter+Locale.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50667F53236117C9D9572E6 /* DateFormatter+Locale.swift */; };
 		83C544D4D4686FA1952B5CDA /* Collection+SubscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEDC9AE444306AE8DFA5B1 /* Collection+SubscriptTests.swift */; };
@@ -62,6 +63,7 @@
 		3E313EC3E53C9ED17660FD3F /* CoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		416ECD39AF17BAA633D3319F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		46C38C292A2CE2A200A8EAE6 /* WeakReferenceProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakReferenceProxy.swift; sourceTree = "<group>"; };
+		46C38C3B2A2CF07C00A8EAE6 /* Date+ISO8601FullDateString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+ISO8601FullDateString.swift"; sourceTree = "<group>"; };
 		5BCC03F920AFF8EA5E089C03 /* Publisher+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Async.swift"; sourceTree = "<group>"; };
 		6EAC707571059C4F574AF288 /* Bundle+Displayname.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Displayname.swift"; sourceTree = "<group>"; };
 		7B04754C559CBA9E8C603FFB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 				F50667F53236117C9D9572E6 /* DateFormatter+Locale.swift */,
 				0F8362B18E5F5925399BE28D /* Sequence+Async.swift */,
 				B416652DCE108D4198E4346C /* String+Random.swift */,
+				46C38C3B2A2CF07C00A8EAE6 /* Date+ISO8601FullDateString.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -389,6 +392,7 @@
 				46C38C2A2A2CE2A200A8EAE6 /* WeakReferenceProxy.swift in Sources */,
 				185B0A89C3A8D35CCD0B09E4 /* AsyncStream+Empty.swift in Sources */,
 				3A59A65FE264F18D0DF5C7AC /* Bundle+Displayname.swift in Sources */,
+				46C38C3C2A2CF07C00A8EAE6 /* Date+ISO8601FullDateString.swift in Sources */,
 				BA2D9C3AA39978DC42C45AA5 /* Collection+Subscript.swift in Sources */,
 				6D676AD58F630C0DC3DA20A5 /* DateFormatter+Locale.swift in Sources */,
 				17DD45C17E35897BE85F130B /* Sequence+Async.swift in Sources */,

--- a/Modules/Foundation/Core/Core.xcodeproj/project.pbxproj
+++ b/Modules/Foundation/Core/Core.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		185B0A89C3A8D35CCD0B09E4 /* AsyncStream+Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 990F480F47C862E63696EECC /* AsyncStream+Empty.swift */; };
 		3A59A65FE264F18D0DF5C7AC /* Bundle+Displayname.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EAC707571059C4F574AF288 /* Bundle+Displayname.swift */; };
 		46C38C2A2A2CE2A200A8EAE6 /* WeakReferenceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C38C292A2CE2A200A8EAE6 /* WeakReferenceProxy.swift */; };
+		46C38C392A2CECCE00A8EAE6 /* String+ISO8601FullDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C38C382A2CECCD00A8EAE6 /* String+ISO8601FullDate.swift */; };
 		46C38C3C2A2CF07C00A8EAE6 /* Date+ISO8601FullDateString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C38C3B2A2CF07C00A8EAE6 /* Date+ISO8601FullDateString.swift */; };
 		5185366F166AC62ACE3B54CD /* Testing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DFA1D869C524184A4F0CB506 /* Testing.framework */; };
 		6D676AD58F630C0DC3DA20A5 /* DateFormatter+Locale.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50667F53236117C9D9572E6 /* DateFormatter+Locale.swift */; };
@@ -63,6 +64,7 @@
 		3E313EC3E53C9ED17660FD3F /* CoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		416ECD39AF17BAA633D3319F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		46C38C292A2CE2A200A8EAE6 /* WeakReferenceProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakReferenceProxy.swift; sourceTree = "<group>"; };
+		46C38C382A2CECCD00A8EAE6 /* String+ISO8601FullDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+ISO8601FullDate.swift"; sourceTree = "<group>"; };
 		46C38C3B2A2CF07C00A8EAE6 /* Date+ISO8601FullDateString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+ISO8601FullDateString.swift"; sourceTree = "<group>"; };
 		5BCC03F920AFF8EA5E089C03 /* Publisher+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Async.swift"; sourceTree = "<group>"; };
 		6EAC707571059C4F574AF288 /* Bundle+Displayname.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Displayname.swift"; sourceTree = "<group>"; };
@@ -198,6 +200,7 @@
 				F50667F53236117C9D9572E6 /* DateFormatter+Locale.swift */,
 				0F8362B18E5F5925399BE28D /* Sequence+Async.swift */,
 				B416652DCE108D4198E4346C /* String+Random.swift */,
+				46C38C382A2CECCD00A8EAE6 /* String+ISO8601FullDate.swift */,
 				46C38C3B2A2CF07C00A8EAE6 /* Date+ISO8601FullDateString.swift */,
 			);
 			path = Foundation;
@@ -388,6 +391,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				46C38C392A2CECCE00A8EAE6 /* String+ISO8601FullDate.swift in Sources */,
 				AE9B9D07BEA80A43539D42AC /* Publisher+Async.swift in Sources */,
 				46C38C2A2A2CE2A200A8EAE6 /* WeakReferenceProxy.swift in Sources */,
 				185B0A89C3A8D35CCD0B09E4 /* AsyncStream+Empty.swift in Sources */,

--- a/Modules/Foundation/Core/Core/Sources/Extensions/Foundation/Date+ISO8601FullDateString.swift
+++ b/Modules/Foundation/Core/Core/Sources/Extensions/Foundation/Date+ISO8601FullDateString.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension Date {
+  public func asISO8601FullDateString() -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+
+    return formatter.string(from: self)
+  }
+}

--- a/Modules/Foundation/Core/Core/Sources/Extensions/Foundation/String+ISO8601FullDate.swift
+++ b/Modules/Foundation/Core/Core/Sources/Extensions/Foundation/String+ISO8601FullDate.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension String {
+  public func asISO8601FullDate() -> Date? {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+
+    return formatter.date(from: self)
+  }
+}

--- a/Modules/Foundation/Networking/NetworkTesting/Sources/Fixtures/DecodingError+Fixtures.swift
+++ b/Modules/Foundation/Networking/NetworkTesting/Sources/Fixtures/DecodingError+Fixtures.swift
@@ -1,0 +1,5 @@
+extension DecodingError {
+  public static func anyDataCorruptedError() -> DecodingError {
+    .dataCorrupted(.init(codingPath: [], debugDescription: ""))
+  }
+}

--- a/Modules/Foundation/Networking/NetworkTesting/Sources/HTTPClient/HTTPClientSpy.swift
+++ b/Modules/Foundation/Networking/NetworkTesting/Sources/HTTPClient/HTTPClientSpy.swift
@@ -13,9 +13,6 @@ public final class HTTPClientSpy: HTTPClient {
   public func get(from url: URL) async throws -> Response {
     requestedURLs.append(url)
 
-    // FIXME: Remove when tests are done, used for simulating wrong replies
-    // try await Task.sleep(for: .seconds(4))
-
     return try result(at: requestedURLs.count - 1, for: url).get()
   }
 

--- a/Modules/Foundation/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Modules/Foundation/Networking/Networking.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -13,6 +13,7 @@
 		3D2F763A4874F7B165839F2E /* URLSessionHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EA079B747B31F72CDEEF5A /* URLSessionHTTPClient.swift */; };
 		3E0236F192B023732972C0C4 /* DefaultJSONDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93C10C532037D8EA2D88CB3 /* DefaultJSONDecoder.swift */; };
 		42876007D9CC989C11F45CC6 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEEBA576B7062577B02E6E02 /* XCTest.framework */; };
+		46C38C412A2CF20A00A8EAE6 /* DecodingError+Fixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C38C402A2CF20A00A8EAE6 /* DecodingError+Fixtures.swift */; };
 		58CF295EECF7CEF11A88967E /* Networking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00D5AC172276CD51B4D7B6CA /* Networking.framework */; };
 		678D3383F695CE3E4FC4C807 /* HTTPClientSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72FFDAB10D8A8238840058F0 /* HTTPClientSpy.swift */; };
 		78B4D93572300BE45A3BA9DA /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4D65BA7816A1F09DEDC07E /* HTTPClient.swift */; };
@@ -91,6 +92,7 @@
 		1E1C7CF12CD91F68064C3DBA /* HTTPURLResponse+StatusCodes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPURLResponse+StatusCodes.swift"; sourceTree = "<group>"; };
 		3F4229F558A337DC183D9832 /* Testing.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Testing.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		40525EC540A9F65E90299FA0 /* URLSessionHTTPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionHTTPClientTests.swift; sourceTree = "<group>"; };
+		46C38C402A2CF20A00A8EAE6 /* DecodingError+Fixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+Fixtures.swift"; sourceTree = "<group>"; };
 		46F89EB7479AB50667762483 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		5E4D65BA7816A1F09DEDC07E /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
 		68D42DE84BC519CF784D5A17 /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -170,6 +172,14 @@
 				E7BB74AA2AA63E5C62286898 /* RemoteLoadingError.swift */,
 			);
 			path = Errors;
+			sourceTree = "<group>";
+		};
+		46C38C3F2A2CF1FA00A8EAE6 /* Fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				46C38C402A2CF20A00A8EAE6 /* DecodingError+Fixtures.swift */,
+			);
+			path = Fixtures;
 			sourceTree = "<group>";
 		};
 		49BB362F3C0CE45DD19D96B6 /* NetworkingTests */ = {
@@ -282,6 +292,7 @@
 		E2AB9DE2F69B8D26B7CACABC /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				46C38C3F2A2CF1FA00A8EAE6 /* Fixtures */,
 				97CCC7C75EC66A236502D51E /* Errors */,
 				5F2877F5559EE18B9D1F9F38 /* HTTPClient */,
 			);
@@ -376,8 +387,6 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1430;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = FEB7E731AD1BAD90CD6A8409 /* Build configuration list for PBXProject "Networking" */;
 			compatibilityVersion = "Xcode 13.0";
@@ -508,6 +517,7 @@
 			files = (
 				3E0236F192B023732972C0C4 /* DefaultJSONDecoder.swift in Sources */,
 				90E8B3A47BE2453327F89E11 /* FailableDecodable.swift in Sources */,
+				46C38C412A2CF20A00A8EAE6 /* DecodingError+Fixtures.swift in Sources */,
 				ED3759173CA967E7C801D334 /* RemoteLoadingError.swift in Sources */,
 				91761CC303D4134F48F3BF7A /* HTTPURLResponse+StatusCodes.swift in Sources */,
 				78B4D93572300BE45A3BA9DA /* HTTPClient.swift in Sources */,

--- a/Modules/Foundation/Testing/Testing.xcodeproj/project.pbxproj
+++ b/Modules/Foundation/Testing/Testing.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -283,8 +283,6 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1430;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = D28845E020C85D395171587F /* Build configuration list for PBXProject "Testing" */;
 			compatibilityVersion = "Xcode 13.0";


### PR DESCRIPTION
This PR focusses on addressing outstanding `TODO`s in the app:
- Extract `String` and `Date` extensions to the `Core` module
- Remove some dead code
- Create a fixture for `DataCorruptedError` in `NetworkTesting` module.
- Remove outdated FIXMEs
