### PR TITLE
Fix minor Image Loading inconsistencies 

### DIFF
--- a/Modules/Features/Album/AlbumIOS/Sources/FeatureFactory/FeatureFactory+AlbumDetail.swift
+++ b/Modules/Features/Album/AlbumIOS/Sources/FeatureFactory/FeatureFactory+AlbumDetail.swift
@@ -24,17 +24,13 @@ extension FeatureFactory {
       client: httpClient
     )
 
-    let remoteImageDataLoader = RemoteImageDataLoader(
-      client: httpClient
-    )
-
     // Adapters
     let albumDetailHeaderModelAdapter = AlbumDetailHeaderModelAdapter(
       albumLoader: remoteAlbumLoader
     )
 
     let imageDataLoadingImageAdapter = ImageDataLoadingImageAdapter(
-      imageDataLoader: remoteImageDataLoader,
+      imageDataLoader: imageLoader,
       dataImageAdapter: UIImage.init(data:)
     )
 

--- a/Modules/Features/Album/AlbumIOS/Sources/FeatureFactory/FeatureFactory+AlbumListViewController.swift
+++ b/Modules/Features/Album/AlbumIOS/Sources/FeatureFactory/FeatureFactory+AlbumListViewController.swift
@@ -20,13 +20,9 @@ extension FeatureFactory {
       client: httpClient
     )
 
-    let remoteImageDataLoader = RemoteImageDataLoader(
-      client: httpClient
-    )
-
     // Adapters
     let imageDataLoadingImageAdapter = ImageDataLoadingImageAdapter(
-      imageDataLoader: remoteImageDataLoader,
+      imageDataLoader: imageLoader,
       dataImageAdapter: UIImage.init(data:)
     )
 

--- a/Modules/Features/Shared/SharedIOS/Sources/ImageTitleRow/ImageTitleRowView.swift
+++ b/Modules/Features/Shared/SharedIOS/Sources/ImageTitleRow/ImageTitleRowView.swift
@@ -20,7 +20,7 @@ public struct ImageTitleRowView<ID: Hashable>: View, ListRowDisplayable {
       Spacer()
       rowChevronIcon
     }
-    .onAppear {
+    .onViewDidLoad {
       viewModel.didAppear()
     }
     .onDisappear {


### PR DESCRIPTION
2 Small inconsistencies were picked up for image loading on the Album List and Album detail.

1. The `ImageTitleRowView` were calling `didAppear` when navigating backwards, this is due to using `onAppear` instead of `viewDidLoad` modifier in view.
2. The Album List and Album Detail was not using the factory image loader, but instead crated there own.

This PR rectifies the above 2 issues.
